### PR TITLE
fix: release pooled client on non-create path + sync production edits

### DIFF
--- a/lib/db.mjs
+++ b/lib/db.mjs
@@ -92,12 +92,12 @@ export async function createTempTable(tableName, columns, tableConfig, timestamp
     throw new Error('Database not initialized');
   }
 
-  const client = await pool.connect();
   const [schema, table] = tableName.split('.');
   const tmpTableName = `${schema}.${table}_tmp`;
   if (event !== 'create') {
     return { tmpTableName };
   }
+  const client = await pool.connect();
   try {
     await client.query('BEGIN');
     logQuery('BEGIN');

--- a/lib/handleJSONL.mjs
+++ b/lib/handleJSONL.mjs
@@ -4,6 +4,12 @@ import moment from 'moment';
 import { sendSlackNotification } from './notifications.mjs';
 import path from 'path';
 
+function waitInSecs(seconds) {
+	  console.log(`\nMemory usage: ${process.memoryUsage().heapUsed / 1024 } KB`);
+console.log(`\nMemory usage: ${process.memoryUsage().heapUsed / 1024 / 1024} MB`);
+  return new Promise(resolve => setTimeout(resolve, seconds * 1000));
+}
+
 export default async function handleJSONL(argv) {
   return new Promise((resolve, _reject) => {
     parseAndTransformJSONL(
@@ -27,6 +33,7 @@ export default async function handleJSONL(argv) {
           await insertBatch(tmpTableName, columns, batch);
           insertedRows += batch.length;
         }
+	      await waitInSecs(10);
 
         // 6 & 7. Handle table swap based on truncate option
         if (argv.truncate && event === 'swap') {

--- a/lib/jsonl.mjs
+++ b/lib/jsonl.mjs
@@ -56,7 +56,7 @@ export async function parseAndTransformJSONL(filePath, tableConfigFile, timezone
           startTime = Date.now();
         }
         // Commit every 50K rows to reduce memory usage
-        const limit = 20000;
+        const limit = 100000;
         if (transformedData.length === limit) {
           console.log(`\nInserting batch of ${noOfRows[currentSheetName]} rows`);
           await callBack({

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "import_to_psql",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Transfer Excel/CSV/JSONL data to PostgreSQL tables",
   "type": "module",
   "bin": {


### PR DESCRIPTION
createTempTable() acquired a client from the pool before its early return for event !== 'create', so every swap/insert leaked a connection. pool.end() in closeDB() then waited forever on the checked-out clients, so import_to_psql hung after finishing all work and had to be killed manually (breaking cron). Move pool.connect() below the early return so a client is only acquired on the path that releases it.

Also captures untracked changes that were running on the worker but never committed:
- handleJSONL: add waitInSecs() pacing (one 10s pause per sheet)
- jsonl: raise batch-commit limit 20000 -> 100000